### PR TITLE
Refactor API tests to use pytest TestClient

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -36,6 +36,7 @@ redis==5.0.1
 # Development and testing
 pytest==7.4.3
 pytest-asyncio==0.21.1
+httpx>=0.25.0
 
 # Database drivers
 psycopg2-binary==2.9.9  # PostgreSQL


### PR DESCRIPTION
## Summary
- replace manual backend API script with pytest tests using FastAPI TestClient
- add httpx dev dependency for TestClient support

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_689731e3287c8328b257d69e634c27c9