### PR TITLE
Ensure auto-created cleaning tasks commit facility updates

### DIFF
--- a/backend/api/crud/cleaning.py
+++ b/backend/api/crud/cleaning.py
@@ -278,11 +278,10 @@ def auto_create_cleaning_tasks(db: Session, checkout_date: date) -> List[Cleanin
             db.add(task)
             created_tasks.append(task)
     
-    if created_tasks:
-        db.commit()
-        for task in created_tasks:
-            db.refresh(task)
-    
+    db.commit()
+    for task in created_tasks:
+        db.refresh(task)
+
     return created_tasks
 
 # ========== シフト関連 ==========

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/backend/tests/test_auto_create_cleaning_tasks.py
+++ b/backend/tests/test_auto_create_cleaning_tasks.py
@@ -1,0 +1,67 @@
+from datetime import date, time
+from pathlib import Path
+import sys
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from api.database import Base
+from api.models.property import Facility
+from api.models.reservation import Reservation
+from api.models.cleaning import CleaningTask as CleaningTaskModel, TaskStatus
+from api.crud import cleaning as crud
+
+
+def test_auto_create_cleaning_tasks_commits_without_tasks():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    db = TestingSessionLocal()
+
+    existing_facility = Facility(name="Existing Facility", is_active=True)
+    db.add(existing_facility)
+    db.commit()
+    db.refresh(existing_facility)
+
+    reservation = Reservation(
+        reservation_id="r1",
+        reservation_type="予約",
+        reservation_number="123",
+        room_type="New Facility",
+        check_in_date=date(2024, 1, 1),
+        check_out_date=date(2024, 1, 2),
+    )
+    db.add(reservation)
+    db.commit()
+    db.refresh(reservation)
+
+    existing_task = CleaningTaskModel(
+        reservation_id=reservation.id,
+        facility_id=existing_facility.id,
+        checkout_date=reservation.check_out_date,
+        checkout_time=time(10, 0),
+        scheduled_date=reservation.check_out_date,
+        scheduled_start_time=time(11, 0),
+        scheduled_end_time=time(13, 0),
+        estimated_duration_minutes=120,
+        priority=3,
+        status=TaskStatus.UNASSIGNED,
+    )
+    db.add(existing_task)
+    db.commit()
+
+    created = crud.auto_create_cleaning_tasks(db, reservation.check_out_date)
+    assert created == []
+    reservation_id = reservation.id
+
+    db.close()
+
+    new_session = TestingSessionLocal()
+    new_facility = new_session.query(Facility).filter_by(name="New Facility").first()
+    assert new_facility is not None
+    updated_reservation = new_session.query(Reservation).filter_by(id=reservation_id).first()
+    assert updated_reservation.facility_id == new_facility.id
+    new_session.close()


### PR DESCRIPTION
## Summary
- Always commit reservation and facility changes in `auto_create_cleaning_tasks`
- Add regression test for committing updates even when no tasks are created
- Configure pytest to only run repository tests

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689731e164748328a08b9f0959c085c8